### PR TITLE
fix can't send file to azure assistant chat

### DIFF
--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -334,7 +334,11 @@ const chatV1 = async (req, res) => {
 
       file_ids = files.map(({ file_id }) => file_id);
       if (file_ids.length || thread_file_ids.length) {
-        userMessage.file_ids = file_ids;
+        //todo set tools by assistants settings
+        userMessage.attachments = file_ids.map((file_id) => ({
+          file_id,
+          tools:[{"type":"file_search"}]
+        }));
         attachedFileIds = new Set([...file_ids, ...thread_file_ids]);
       }
     };


### PR DESCRIPTION
create thread to azure assistants still use assistants V1 API  that not supported by azure