### PR TITLE
fix: azureAssistants and azureOpenAI can't work together

### DIFF
--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -109,7 +109,7 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
     azureOptions = currentOptions;
 
     baseURL = constructAzureURL({
-      baseURL: azureBaseURL ?? 'https://${INSTANCE_NAME}.openai.azure.com/openai',
+      baseURL: 'https://${INSTANCE_NAME}.openai.azure.com/openai',
       azureOptions,
     });
 


### PR DESCRIPTION
不配置baseURL就可以work了

```
azure openai and asssisent API baseURL 冲突的问题

因为azure chat和 assistant 的baseURL前缀不同导致：

配置 baseURL: "https://${INSTANCE_NAME}.openai.azure.com/openai/deployments/${DEPLOYMENT_NAME}"
chat正常，但是azure asssisent 不正常, 发送到了  https://glean-prod.openai.azure.com/openai/deployments/gpt-4o

Chat 正常请求路径
curl -X POST "https://glean-prod.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-05-01-preview" \
-H "api-key:<>" \
-H "Content-Type: application/json" \
-d '{
    "model": "gpt-4o",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'



配置 https://${INSTANCE_NAME}.openai.azure.com/openai/
chat不正常，azure asssisent 正常
发送chat的命令错误



解决办法：配置成[https://${INSTANCE_NAME}.openai.azure.com/openai/deployments/${DEPLOYMENT_NAME}](https://${instance_name}.openai.azure.com/openai/deployments/$%7BDEPLOYMENT_NAME%7D)
修改api/server/services/Endpoints/azureAssistants/initialize.js 固定写死 https://${instance_name}.openai.azure.com/openai 

Update：
不配置BaseURL就行，不用修改代码
```